### PR TITLE
Command line interface helpers

### DIFF
--- a/pkg/helpers/cmd.go
+++ b/pkg/helpers/cmd.go
@@ -1,0 +1,15 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+)
+
+func PrintError(err error) {
+	fmt.Fprintln(os.Stderr, err)
+}
+
+func PrintErrorAndExit(err error) {
+	PrintError(err)
+	os.Exit(1)
+}


### PR DESCRIPTION
Adicionado 2 função auxiliares para exibir erros e encerrar a aplicação, pois acredito que esse código pode ser útil para diversos comandos que nossa aplicação possa ter.

Implementei essa funções no pacote `pkg/helpers`, pois acredito que a funcionalidade das mesmas é genérica o suficiente para poder ser usada em outras aplicações caso seja desejado.