### PR TITLE
Correção do warning "loop variable content captured by func literal"

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -64,13 +64,13 @@ func runAnalyze(cmd *cobra.Command, args []string) {
 		for content := range r.Out() {
 			wg.Add(1)
 
-			go func() {
+			go func(fileContents []byte) {
 				defer wg.Done()
 				e := getAnalyzeEngine()
-				if err := e.Run(content); err != nil {
+				if err := e.Run(fileContents); err != nil {
 					errChanel <- err
 				}
-			}()
+			}(content)
 		}
 
 		// Wait all engine goroutine finish


### PR DESCRIPTION
No comando "analyze" o go estava reportando o seguinte erro: "loop variable content captured by func literal", isto é, basicamente estávamos passando a referencia de um valor que era alterado em cada loop para um clojure que era executada em um goroutine paralela, assim o seu valor poderia ser alterado.